### PR TITLE
Fix checkPlayState taking CRC from index 4 instead of 5

### DIFF
--- a/src/DYPlayer.cpp
+++ b/src/DYPlayer.cpp
@@ -93,8 +93,8 @@ namespace DY {
   play_state_t DYPlayer::checkPlayState() {
     uint8_t command[3] = { 0xaa, 0x01, 0x00 };
     sendCommand(command, 3, 0xab);
-    uint8_t buffer[6];
-    if (getResponse(buffer, 6)) {
+    uint8_t buffer[5];
+    if (getResponse(buffer, 5)) {
       return (play_state_t) buffer[3];
     }
     return PlayState::Fail;


### PR DESCRIPTION
Hi, thanks for writing this library!

I got stuck with not being able to get the play state, so went in and tried to send the bytes for playback and getplaystate manually, printing the result over another serial. I noticed that you create a buffer of 6 bytes and send that to the validateCRC function which takes the last byte for CRC, which is always 0. When reducing the buffer by 1 it works fine. The actual result is also taken from the byte before that.

```
Playback: AA 01 01 01 AD 00
 Stopped: AA 01 01 00 AC 00

                          ^-- before patch CRC taken from here
                       ^-- after patch CRC taken from here
```

I'm using a DY-SV17F on Attiny841 using hw serial.

After the patch it works fine here.

Best regards,

Leon
