### PR TITLE
Fix software serial for ESP8266 in PlatformIO

### DIFF
--- a/src/DYPlayerArduino.cpp
+++ b/src/DYPlayerArduino.cpp
@@ -16,17 +16,13 @@ namespace DY {
     this->isSoftSerial = false;
   }
 #endif
-#ifdef __AVR__
   Player::Player(SoftwareSerial* port) {
     this->port = (Stream*)port;
     this->isSoftSerial = true;
   }
-#endif
   void Player::begin() {
     if (isSoftSerial) {
-#ifdef __AVR__
       ((SoftwareSerial*)port)->begin(9600);
-#endif
     } else {
 #ifdef HAVE_HWSERIAL0
       ((HardwareSerial*)port)->begin(9600);

--- a/src/DYPlayerArduino.h
+++ b/src/DYPlayerArduino.h
@@ -3,9 +3,7 @@
 #include "DYPlayer.h"
 
 // Include SoftwareSerial for Arduino boards that probably support it.
-#ifdef __AVR__
 #include "SoftwareSerial.h"
-#endif
 
 namespace DY {
   class Player: public DYPlayer {
@@ -16,9 +14,7 @@ namespace DY {
 #ifdef HAVE_HWSERIAL0
       Player(HardwareSerial* port);
 #endif
-#ifdef __AVR__
       Player(SoftwareSerial* port);
-#endif
       void begin();
       void serialWrite(uint8_t *buffer, uint8_t len);
       bool serialRead(uint8_t *buffer, uint8_t len);


### PR DESCRIPTION
Hi,

For me to get software serial working on an ESP8266 using PlatformIO (and Visual Studio Code) I had to remove the `#ifdef __AVR__` from the library. This may also fix #32 
I don't know much about this platform/Arduino thingy, so this might not be the correct way to do it, but it works for me.
What do you think?

woutput